### PR TITLE
Allow for clean-css-promise in broccoli-clean-css

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const CleanCss = require('clean-css');
 
 module.exports = class CleanCssPromise extends CleanCss {
   minify(source) {
+    const options = this.options;
     const originalMinify = super.minify.bind(this);
     return new Promise(function promisify(resolve, reject) {
       originalMinify(source, function minifyCallback(errors, result) {
-        if (errors) {
+        if (errors && !options.disableStrict) {
           reject(arrayToError(errors));
           return;
         }


### PR DESCRIPTION
This is to allow for broccoli-clean-css to pass `disableStrict: true` so it can undo the semver break in 1.1.0 without breaking `clean-css-promise`.

https://github.com/shinnn/broccoli-clean-css/issues/14
